### PR TITLE
Key locking fixes

### DIFF
--- a/scripts/lock
+++ b/scripts/lock
@@ -106,10 +106,10 @@ LockSystem() {
         lock=$(LockName "$system")
         comm="chmod u+w '$lock' && echo -n '${key}' > '$lock' && chmod u-w '$lock'"
         RemoteCommand "${comm}"
+        return $?
     fi
 
-    # $? should now be 0 or exit code of RemoteCommand
-    return $?
+    return 0
 }
 
 UnlockSystem() {


### PR DESCRIPTION
The conversion to POSIX shell exposed a few edge case I am hitting with the regression test.

Specifically:
- locks can be strings (needed to change a few numeric comparisons)
- some result value computations/comparisons were now slightly off sometimes
- explicitly calling `/bin/sh` with `RemoteCommand` failed for `chmod`
- directly returning the result of `[ .. ]` failed (not sure why this is, but it did)

These commits should fix those issues. I've tested them locally, but not in the regression test yet.