### PR TITLE
remote: configure ssh not to produce \r\n

### DIFF
--- a/mq.sh
+++ b/mq.sh
@@ -68,7 +68,6 @@ fi
 
 # Check the version of our scripts compared to the canonical host
 if ! RemoteCommand cat "${BASE}/VERSION" |
-	tr -d '\r' |
 	diff "${SCRIPT_PATH}/VERSION" -
 then
     echo "Local version of mq.sh appears to differ from version on ${HOST} at ${BASE}"

--- a/scripts/lock
+++ b/scripts/lock
@@ -47,7 +47,7 @@ LockSystemPrintInfo() {
         echo "Lock for $system currently free"
         return;
     fi
-    printf "Lock for $system held by $owner since $since" | tr -d '\r'
+    printf "Lock for $system held by $owner since $since"
     if [ "${lockkey}" != "0" ]; then
         echo " with key '${lockkey}'"
     else
@@ -135,9 +135,7 @@ CancelWait() {
     system="$1"
     key="$2"
 
-    # Don't know why there is an \r at the end of REMOTEUSER, but there is. Maybe RemoteCommand produces them?
-    user=$(printf "${REMOTEUSER}" | tr -d '\r')
-    RemoteCommand "pkill -u ${user} -f \"lockfile.*'${key}' > '$(KeyName "${system}")'\""
+    RemoteCommand "pkill -u ${REMOTEUSER} -f \"lockfile.*'${key}' > '$(KeyName "${system}")'\""
 }
 
 UserLockUsage() {

--- a/scripts/remote
+++ b/scripts/remote
@@ -9,7 +9,7 @@ RemoteCommandOn() {
     host="$1"
     shift
     cmd="$@"
-    ssh -tt -oLogLevel=quiet "${host}" "stty isig -echoctl -echo ; $cmd"
+    ssh -tt -oLogLevel=quiet "${host}" "stty isig -onlcr -echoctl -echo ; $cmd"
     return $?
 }
 

--- a/scripts/runner
+++ b/scripts/runner
@@ -45,10 +45,6 @@ RebootConsoleRunTwoFiles() {
         # need to copy remotely
         kernelfile=$(RemoteCommandOn ${HOST} "mktemp")
         rootserverfile=$(RemoteCommandOn ${HOST} "mktemp")
-        # Strip trailing \r
-        kernelfile=$(printf "${kernelfile}" | tr -d '\r')
-        rootserverfile=$(printf "${rootserverfile}" | tr -d '\r')
-        logfile=$(printf "${logfile}" | tr -d '\r')
         if ! scp "${kernel}" "${HOST}:${kernelfile}"; then
             echo "Failed to copy kernel image"
             RemoteCommandOn ${HOST} rm "${kernelfile}"
@@ -101,9 +97,6 @@ RebootConsoleRunOneFile() {
         logfile=$(RemoteCommandOn ${HOST} "mktemp")
         # need to copy remotely
         kernelfile=$(RemoteCommandOn ${HOST} "mktemp")
-        # Strip trailing \r
-        kernelfile=$(printf "${kernelfile}" | tr -d '\r')
-        logfile=$(printf "${logfile}" | tr -d '\r')
         if ! scp "${kernel}" "${HOST}:${kernelfile}"; then
             echo "Failed to copy kernel image"
             RemoteCommandOn ${HOST} rm "${kernelfile}"


### PR DESCRIPTION
The default configuration produced \r\n for newlines (with -t, which we
used), leaving \r characters in the output at unexpected places. This
configures ssh not to do that, and removes the `tr -d '\r'` sprinkled
through the code.

We only do this for RemoteCommand, where we expect one-line output,
because the terminal does actually seem to expect \r characters for
multi-line things.
