### PR TITLE
Fix 'mq sem dumpall' on macOS

### DIFF
--- a/scripts/lock
+++ b/scripts/lock
@@ -32,7 +32,7 @@ LockIOwn() {
 
 GetAllLockedSystems() {
     RemoteCommand find ${BASE} -name '*.lock' -print0 |
-    xargs -0 -i basename {} .lock
+    xargs -0 -I {} basename {} .lock
     echo
 }
 
@@ -62,17 +62,17 @@ LockSystemDumpInfo() {
     owner=$(echo "$info" | cut -d ',' -f 1)
     since=$(echo "$info" | cut -d ',' -f 2)
     lockkey=$(LockGetKey "${system}")
-    echo -n $system
+    printf "$system"
     if [ "${owner}" = "" ];
     then
-    echo -n " FREE"
+    printf " FREE"
     else
-    echo -n " LOCKED"
-    echo -n " $owner"
-    echo -n " $since"
+    printf " LOCKED"
+    printf " $owner"
+    printf " $since"
         if [ "${lockkey}" != "0" ];
     then
-            echo -n " ${lockkey}"
+            printf " ${lockkey}"
     fi
     fi
     echo


### PR DESCRIPTION
Whichever version of echo is invoked by /bin/sh on macOS does not
support the -n option, so I replaced calls to echo -n with printf.

Likewise, the version of xargs shipped with macOS does not support the
-i option: instead you need -I {}. GNU xargs supports both and the
manual states that -i is deprecated in favour of -I.