### PR TITLE
Dtb selection

### DIFF
--- a/mq.sh
+++ b/mq.sh
@@ -24,8 +24,9 @@ Usage () {
     echo
     echo "  run         Run a new job on a machine"
     echo "  systems     Query information on available machines"
-    echo "  system-tsv  List available machines as TSV"
+    echo "  system-tsv  List available machines as tab-separated values"
     echo "  pool-tsv    List available machine pools as tab-separated lists"
+    echo "  features    List which boards support non-standard features"
     echo
     echo "  sem         Directly interact with the machine locks"
     echo
@@ -51,6 +52,10 @@ case "$command" in
     ;;
     pool-tsv)
         OutputPoolTSV
+        exit 0
+    ;;
+    features)
+        OutputFeatureList
         exit 0
     ;;
     help)

--- a/scripts/enqueue
+++ b/scripts/enqueue
@@ -34,6 +34,7 @@ EnqueueUsage() {
     echo " -k KEY      Key for obtaining the lock"
     echo " -l FILE     Optional location to write all the console output to"
     echo " -L          This is a Linux image not seL4"
+    echo " -b FILE     Dtb to use instead of the default one with a Linux image"
     echo " -s TEXT     Specifies which machine this job is for"
     echo " -f FILE [+] Files to use as the job image"
     echo " -w TIME     Number of seconds to wait between each attempt to acquire the lock (default 8)"
@@ -62,6 +63,15 @@ Enqueue() {
 	    -L)
 		linux="-L"
 	    ;;
+            -b)
+                if ! [ -f "$2" ]; then
+                    echo "dtb file \"$2\" either does not exist, or is not considered a valid file"
+                    exit -1
+                fi
+
+                # We want the var to contain "-b my.dtb" so we can identify
+                # that it is a dtb later
+                dtbflag="$1 $2"
             -l)
                 shift
                 logfile="$1"
@@ -204,9 +214,13 @@ Enqueue() {
         echo "Attempting to power off machine now that you are done"
         SystemPowerOff "${system}"
     else
-        # Run the image. 'files' is deliberately no in quotes so the multiple
+        # Run the image. 'files' is deliberately not in quotes so the multiple
         # files expands to multiple arguments
-        SystemRunImage "${system}" "${completion}" "${completion_timeout}" "${errortxt}" "${logfile}" "${keep_alive}" ${linux} $files
+        # 'dtbflag' is deliberately not in quotes so it expands to multiple
+        # parameters '-b' and 'my.dtb'
+        # 'linux' is deliberately not in quotes so it will not create an empty
+        # parameter if the flag is not set
+        SystemRunImage "${system}" "${completion}" "${completion_timeout}" "${errortxt}" "${logfile}" "${keep_alive}" ${linux} ${dtbflag} $files
         ret=$?
     fi
 

--- a/scripts/enqueue
+++ b/scripts/enqueue
@@ -10,7 +10,7 @@ fi
 SIGNALS="INT TERM HUP QUIT KILL PIPE"
 
 EnqueueUsage() {
-    echo "$0 run -r|-c <string> -l logfile -s system [-w retry-time] [-t retry-count] [-n] [-a] [-d timeout] [-e <string>] [-k <string>] [-L] -f file1 -f file2 .. -f filen"
+    echo "$0 run -r|-c <string> -l logfile -s system [-w retry-time] [-t retry-count] [-n] [-a] [-d timeout] [-e <string>] [-k <string>] [-L] [-b <file>] -f file1 -f file2 .. -f filen"
     echo
     echo "   Acquires a lock for a machine, and once locked runs the specified job"
     echo "   Jobs can include just a reservation"
@@ -60,18 +60,20 @@ Enqueue() {
     key="0"
     while [ "$#" -ne 0 ]; do
         case "$1" in
-	    -L)
-		linux="-L"
-	    ;;
+            -L)
+                linux="-L"
+            ;;
             -b)
-                if ! [ -f "$2" ]; then
-                    echo "dtb file \"$2\" either does not exist, or is not considered a valid file"
+                shift
+                if ! [ -f "$1" ]; then
+                    echo "dtb file \"$1\" either does not exist, or is not considered a valid file"
                     exit -1
                 fi
 
                 # We want the var to contain "-b my.dtb" so we can identify
                 # that it is a dtb later
-                dtbflag="$1 $2"
+                dtbflag="-b $1"
+            ;;
             -l)
                 shift
                 logfile="$1"
@@ -145,6 +147,25 @@ Enqueue() {
         esac
         shift
     done
+
+    if [ ! -z "linux" ]; then
+        if ! SystemBootsLinuxPXE "${system}" ; then
+            echo "System cannot boot Linux over the network."
+            exit 1
+        fi
+    fi
+
+    if [ ! -z "$dtbflag" ]; then
+        if ! SystemAcceptsDtb "${system}" ; then
+            echo "System does not accept a dtb"
+            exit 1
+        fi
+    fi
+
+    if [ ! -z "$dtbflag" ] && [ -z $linux ]; then
+        echo "A dtb may only be supplied when booting a linux image over the network."
+        exit 1
+    fi
 
     # Check that we got enough parameters
     if [ ! "$system" ]; then

--- a/scripts/runner
+++ b/scripts/runner
@@ -26,6 +26,12 @@ RebootConsoleRunTwoFiles() {
 	linux="-L"
 	shift
     }
+    [ "$1" = '-b' ] && {
+        dtb="$2"
+        dtbflag="$1 $2"
+        shift
+        shift
+    }
     completion="$1"
     completion_timeout="$2"
     errortxt="$3"
@@ -49,6 +55,7 @@ RebootConsoleRunTwoFiles() {
         # need to copy remotely
         kernelfile=$(RemoteCommandOn ${HOST} "mktemp")
         rootserverfile=$(RemoteCommandOn ${HOST} "mktemp")
+        dtbfile=$(RemoteCommandOn ${HOST} "mktemp")
         if ! scp "${kernel}" "${HOST}:${kernelfile}"; then
             echo "Failed to copy kernel image"
             RemoteCommandOn ${HOST} rm "${kernelfile}"
@@ -63,6 +70,17 @@ RebootConsoleRunTwoFiles() {
             RemoteCommandOn ${HOST} rm "${logfile}"
             return 1
         fi
+        if [ ! -z "${dtb}" ]; then
+            if ! scp "${dtb}" "${HOST}:${dtbfile}"; then
+                echo "Failed to copy dtb file"
+                RemoteCommandOn ${HOST} rm "${kernelfile}"
+                RemoteCommandOn ${HOST} rm "${rootserverfile}"
+                RemoteCommandOn ${HOST} rm "${logfile}"
+                RemoteCommandOn ${HOST} rm "${dtbfile}"
+                return 1
+            fi
+        fi
+
         ssh -tt -oLogLevel=quiet ${HOST} "stty isig -echoctl -echo; /tftpboot/${machine}/reboot $linux -l '${logfile}' -c '${completion}' -t '${completion_timeout}' -e '${errortxt}' -k '${kernelfile}' -u '${rootserverfile}' ${ka_flag}"
         ret=$?
         if [ "${output}" != "" ]; then
@@ -71,12 +89,15 @@ RebootConsoleRunTwoFiles() {
         RemoteCommandOn ${HOST} rm "${kernelfile}"
         RemoteCommandOn ${HOST} rm "${rootserverfile}"
         RemoteCommandOn ${HOST} rm "${logfile}"
+        if [ ! -z "${dtb}" ]; then
+            RemoteCommandOn ${HOST} rm "${dtbfile}"
+        fi
         return $ret
     fi
     if [ "${output}" = "" ]; then
-        "/tftpboot/${machine}/reboot"  $linux -t "${completion_timeout}" -c "${completion}" -e "${errortxt}" -k "${kernel}" -u "${rootserver}" ${ka_flag}
+        "/tftpboot/${machine}/reboot"  $linux $dtbflag -t "${completion_timeout}" -c "${completion}" -e "${errortxt}" -k "${kernel}" -u "${rootserver}" ${ka_flag}
     else
-        "/tftpboot/${machine}/reboot" $linux -t "${completion_timeout}" -c "${completion}" -e "${errortxt}" -l "${output}" -k "${kernel}" -u "${rootserver}" ${ka_flag}
+        "/tftpboot/${machine}/reboot" $linux $dtbflag -t "${completion_timeout}" -c "${completion}" -e "${errortxt}" -l "${output}" -k "${kernel}" -u "${rootserver}" ${ka_flag}
     fi
 }
 
@@ -84,6 +105,12 @@ RebootConsoleRunOneFile() {
     [ "$1" = '-L' ] && {
 	linux="-L"
 	shift
+    }
+    [ "$1" = '-b' ] && {
+    dtb="$2"
+    dtbflag="$1 $2"
+    shift
+    shift
     }
     completion=$1
     completion_timeout=$2
@@ -105,24 +132,37 @@ RebootConsoleRunOneFile() {
         logfile=$(RemoteCommandOn ${HOST} "mktemp")
         # need to copy remotely
         kernelfile=$(RemoteCommandOn ${HOST} "mktemp")
+        dtbfile=$(RemoteCommandOn ${HOST} "mktemp")
         if ! scp "${kernel}" "${HOST}:${kernelfile}"; then
             echo "Failed to copy kernel image"
             RemoteCommandOn ${HOST} rm "${kernelfile}"
             RemoteCommandOn ${HOST} rm "${logfile}"
             return 1
         fi
-        ssh -tt -oLogLevel=quiet ${HOST} "stty isig -echoctl -echo; /tftpboot/${machine}/reboot $linux -l '${logfile}' -c '${completion}' -t '${completion_timeout}' -e '${errortxt}' -k '${kernelfile}' ${ka_flag}"
+        if [ ! -z "${dtb}" ]; then
+            if ! scp "${dtb}" "${HOST}:${kernelfile}"; then
+                echo "Failed to copy dtb file"
+                RemoteCommandOn ${HOST} rm "${dtbfile}"
+                RemoteCommandOn ${HOST} rm "${kernelfile}"
+                RemoteCommandOn ${HOST} rm "${logfile}"
+            fi
+        fi
+
+        ssh -tt -oLogLevel=quiet ${HOST} "stty isig -echoctl -echo; /tftpboot/${machine}/reboot $linux $dtbflag -l '${logfile}' -c '${completion}' -t '${completion_timeout}' -e '${errortxt}' -k '${kernelfile}' ${ka_flag}"
         ret=$?
         if [ "${output}" != "" ]; then
             scp "${HOST}:${logfile}" "${output}"
         fi
         RemoteCommandOn ${HOST} rm "${kernelfile}"
         RemoteCommandOn ${HOST} rm "${logfile}"
+        if [ ! -z "${dtb}" ]; then
+            RemoteCommandOn ${HOST} rm "${dtbfile}"
+        fi
         return $ret
     fi
     if [ "${output}" = "" ]; then
-        "/tftpboot/${machine}/reboot" $linux -t "${completion_timeout}" -c "${completion}" -e "${errortxt}" -k "${kernel}" ${ka_flag}
+        "/tftpboot/${machine}/reboot" $linux $dtbflag -t "${completion_timeout}" -c "${completion}" -e "${errortxt}" -k "${kernel}" ${ka_flag}
     else
-        "/tftpboot/${machine}/reboot" $linux -t "${completion_timeout}" -c "${completion}" -e "${errortxt}" -l "${output}" -k "${kernel}" ${ka_flag}
+        "/tftpboot/${machine}/reboot" $linux $dtbflag -t "${completion_timeout}" -c "${completion}" -e "${errortxt}" -l "${output}" -k "${kernel}" ${ka_flag}
     fi
 }

--- a/scripts/runner
+++ b/scripts/runner
@@ -27,9 +27,8 @@ RebootConsoleRunTwoFiles() {
 	shift
     }
     [ "$1" = '-b' ] && {
-        dtb="$2"
-        dtbflag="$1 $2"
         shift
+        dtb="$1"
         shift
     }
     completion="$1"
@@ -55,7 +54,6 @@ RebootConsoleRunTwoFiles() {
         # need to copy remotely
         kernelfile=$(RemoteCommandOn ${HOST} "mktemp")
         rootserverfile=$(RemoteCommandOn ${HOST} "mktemp")
-        dtbfile=$(RemoteCommandOn ${HOST} "mktemp")
         if ! scp "${kernel}" "${HOST}:${kernelfile}"; then
             echo "Failed to copy kernel image"
             RemoteCommandOn ${HOST} rm "${kernelfile}"
@@ -71,6 +69,8 @@ RebootConsoleRunTwoFiles() {
             return 1
         fi
         if [ ! -z "${dtb}" ]; then
+            dtbfile=$(RemoteCommandOn ${HOST} "mktemp")
+            dtbflag="-b $dtbfile"
             if ! scp "${dtb}" "${HOST}:${dtbfile}"; then
                 echo "Failed to copy dtb file"
                 RemoteCommandOn ${HOST} rm "${kernelfile}"
@@ -81,7 +81,7 @@ RebootConsoleRunTwoFiles() {
             fi
         fi
 
-        ssh -tt -oLogLevel=quiet ${HOST} "stty isig -echoctl -echo; /tftpboot/${machine}/reboot $linux -l '${logfile}' -c '${completion}' -t '${completion_timeout}' -e '${errortxt}' -k '${kernelfile}' -u '${rootserverfile}' ${ka_flag}"
+        ssh -tt -oLogLevel=quiet ${HOST} "stty isig -echoctl -echo; /tftpboot/${machine}/reboot $linux $dtbflag -l '${logfile}' -c '${completion}' -t '${completion_timeout}' -e '${errortxt}' -k '${kernelfile}' -u '${rootserverfile}' ${ka_flag}"
         ret=$?
         if [ "${output}" != "" ]; then
             scp "${HOST}:${logfile}" "${output}"
@@ -107,9 +107,8 @@ RebootConsoleRunOneFile() {
 	shift
     }
     [ "$1" = '-b' ] && {
-    dtb="$2"
-    dtbflag="$1 $2"
     shift
+    dtb="$1"
     shift
     }
     completion=$1
@@ -132,7 +131,6 @@ RebootConsoleRunOneFile() {
         logfile=$(RemoteCommandOn ${HOST} "mktemp")
         # need to copy remotely
         kernelfile=$(RemoteCommandOn ${HOST} "mktemp")
-        dtbfile=$(RemoteCommandOn ${HOST} "mktemp")
         if ! scp "${kernel}" "${HOST}:${kernelfile}"; then
             echo "Failed to copy kernel image"
             RemoteCommandOn ${HOST} rm "${kernelfile}"
@@ -140,6 +138,8 @@ RebootConsoleRunOneFile() {
             return 1
         fi
         if [ ! -z "${dtb}" ]; then
+            dtbfile=$(RemoteCommandOn ${HOST} "mktemp")
+            dtbflag="-b $dtbfile"
             if ! scp "${dtb}" "${HOST}:${kernelfile}"; then
                 echo "Failed to copy dtb file"
                 RemoteCommandOn ${HOST} rm "${dtbfile}"

--- a/scripts/system
+++ b/scripts/system
@@ -10,6 +10,16 @@ IsSystemValid() {
     [ -f "${SCRIPT_PATH}/scripts/systems/${system}" ]
 }
 
+SystemAcceptsDtb() {
+    system="$1"
+    [ "$("DTB_${system}")" = "yes" ]
+}
+
+SystemBootsLinuxPXE() {
+    system="$1"
+    [ "$("PXELinux_${system}")" = "yes" ]
+}
+
 SystemList() {
     (
 	cd "${SCRIPT_PATH}/scripts/systems/"
@@ -121,10 +131,9 @@ SystemRunImage() {
 	kernel="$7"
     }
 
-    [ $kernel = "-b"] && {
+    [ $kernel = "-b" ] && {
         dtbflag="$7 $8"
-        shift
-        shift
+        shift 2
         kernel="$7"
     }
     system_name="$("SystemName_${system}")"
@@ -133,6 +142,6 @@ SystemRunImage() {
         rootserver="$8"
         RebootConsoleRunTwoFiles $linux $dtbflag "${completion}" "${completion_timeout}" "${errortxt}" "${logfile}" "${keep_alive}" "${kernel}" "${rootserver}" "${system_name}"
     else
-        RebootConsoleRunOneFile $linux $dtbflag"${completion}" "${completion_timeout}" "${errortxt}" "${logfile}" "${keep_alive}" "${kernel}" "${system_name}"
+        RebootConsoleRunOneFile $linux $dtbflag "${completion}" "${completion_timeout}" "${errortxt}" "${logfile}" "${keep_alive}" "${kernel}" "${system_name}"
     fi
 }

--- a/scripts/system
+++ b/scripts/system
@@ -55,6 +55,20 @@ OutputSystemList() {
     OutputPoolList
 }
 
+OutputFeatureList() {
+    printf "+----------------+----------------+------------+\n"
+    printf "| Name           | PXE boot Linux | Custom DTB |\n"
+    printf "+----------------+----------------+------------+\n"
+    for system in $(SystemList)
+    do
+        printf "| %14s " "${system}"
+        printf "| %14s " "$("PXELinux_${system}")"
+        printf "| %10s " "$("DTB_${system}")"
+        printf "|\n"
+    done
+    printf "+----------------+----------------+------------+\n"
+}
+
 OutputSystemTSV() {
     printf "name\tarch\tsel4_plat\tisa\tsoc\tcpu\tcores\tram\tmax_clk\tnum_files\n"
     for system in $(SystemList)
@@ -106,12 +120,19 @@ SystemRunImage() {
 	shift
 	kernel="$7"
     }
+
+    [ $kernel = "-b"] && {
+        dtbflag="$7 $8"
+        shift
+        shift
+        kernel="$7"
+    }
     system_name="$("SystemName_${system}")"
 
     if [ "$("SystemNumFiles_${system}" $linux)" -eq 2 ]; then
         rootserver="$8"
-        RebootConsoleRunTwoFiles $linux "${completion}" "${completion_timeout}" "${errortxt}" "${logfile}" "${keep_alive}" "${kernel}" "${rootserver}" "${system_name}"
+        RebootConsoleRunTwoFiles $linux $dtbflag "${completion}" "${completion_timeout}" "${errortxt}" "${logfile}" "${keep_alive}" "${kernel}" "${rootserver}" "${system_name}"
     else
-        RebootConsoleRunOneFile $linux "${completion}" "${completion_timeout}" "${errortxt}" "${logfile}" "${keep_alive}" "${kernel}" "${system_name}"
+        RebootConsoleRunOneFile $linux $dtbflag"${completion}" "${completion_timeout}" "${errortxt}" "${logfile}" "${keep_alive}" "${kernel}" "${system_name}"
     fi
 }

--- a/scripts/systems/bboneblack
+++ b/scripts/systems/bboneblack
@@ -48,3 +48,11 @@ MaxCLK_bboneblack() {
 Sel4Plat_bboneblack() {
     echo "am335x:am335x-boneblack"
 }
+
+PXELinux_bboneblack() {
+    echo "no"
+}
+
+DTB_bboneblack() {
+    echo "no"
+}

--- a/scripts/systems/beagle
+++ b/scripts/systems/beagle
@@ -48,3 +48,12 @@ MaxCLK_beagle() {
 Sel4Plat_beagle() {
     echo "omap3"
 }
+
+PXELinux_beagle() {
+    echo "no"
+}
+
+DTB_beagle() {
+    echo "no"
+}
+

--- a/scripts/systems/colorado2
+++ b/scripts/systems/colorado2
@@ -48,3 +48,12 @@ MaxCLK_colorado2() {
 Sel4Plat_colorado2() {
     echo "tk1"
 }
+
+PXELinux_colorado2() {
+    echo "no"
+}
+
+DTB_colorado2() {
+    echo "no"
+}
+

--- a/scripts/systems/haswell1
+++ b/scripts/systems/haswell1
@@ -48,3 +48,12 @@ MaxCLK_haswell1() {
 Sel4Plat_haswell1() {
     echo "pc99:haswell"
 }
+
+PXELinux_haswell1() {
+    echo "no"
+}
+
+DTB_haswell1() {
+    echo "no"
+}
+

--- a/scripts/systems/haswell3
+++ b/scripts/systems/haswell3
@@ -48,3 +48,11 @@ MaxCLK_haswell3() {
 Sel4Plat_haswell3() {
     echo "pc99:haswell"
 }
+
+PXELinux_haswell3() {
+    echo "yes"
+}
+
+DTB_haswell3() {
+    echo "no"
+}

--- a/scripts/systems/haswell4
+++ b/scripts/systems/haswell4
@@ -48,3 +48,11 @@ MaxCLK_haswell4() {
 Sel4Plat_haswell4() {
     echo "pc99:haswell"
 }
+
+PXELinux_haswell4() {
+    echo "yes"
+}
+
+DTB_haswell4() {
+    echo "no"
+}

--- a/scripts/systems/hifive
+++ b/scripts/systems/hifive
@@ -48,3 +48,11 @@ MaxCLK_hifive() {
 Sel4Plat_hifive() {
     echo "hifive"
 }
+
+PXELinux_hifive() {
+    echo "no"
+}
+
+DTB_hifive() {
+    echo "no"
+}

--- a/scripts/systems/hifive1
+++ b/scripts/systems/hifive1
@@ -48,3 +48,11 @@ MaxCLK_hifive1() {
 Sel4Plat_hifive1() {
     echo "hifive"
 }
+
+PXELinux_hifive1() {
+    echo "no"
+}
+
+DTB_hifive1() {
+    echo "no"
+}

--- a/scripts/systems/hikey
+++ b/scripts/systems/hikey
@@ -48,3 +48,11 @@ MaxCLK_hikey() {
 Sel4Plat_hikey() {
     echo "hikey"
 }
+
+PXELinux_hikey() {
+    echo "no"
+}
+
+DTB_hikey() {
+    echo "no"
+}

--- a/scripts/systems/imx8mm
+++ b/scripts/systems/imx8mm
@@ -53,3 +53,11 @@ MaxCLK_imx8mm() {
 Sel4Plat_imx8mm() {
     echo "imx8mm-evk"
 }
+
+PXELinux_imx8mm() {
+    echo "yes"
+}
+
+DTB_imx8mm() {
+    echo "yes"
+}

--- a/scripts/systems/imx8mq
+++ b/scripts/systems/imx8mq
@@ -48,3 +48,11 @@ MaxCLK_imx8mq() {
 Sel4Plat_imx8mq() {
     echo "imx8mq-evk"
 }
+
+PXELinux_imx8mq() {
+    echo "no"
+}
+
+DTB_imx8mq() {
+    echo "no"
+}

--- a/scripts/systems/imx8mq2
+++ b/scripts/systems/imx8mq2
@@ -48,3 +48,11 @@ MaxCLK_imx8mq2() {
 Sel4Plat_imx8mq2() {
     echo "imx8mq-evk"
 }
+
+PXELinux_imx8mq2() {
+    echo "no"
+}
+
+DTB_imx8mq2() {
+    echo "no"
+}

--- a/scripts/systems/jetson1
+++ b/scripts/systems/jetson1
@@ -48,3 +48,11 @@ MaxCLK_jetson1() {
 Sel4Plat_jetson1() {
     echo "tk1"
 }
+
+PXELinux_jetson1() {
+    echo "no"
+}
+
+DTB_jetson1() {
+    echo "no"
+}

--- a/scripts/systems/maaxboard1
+++ b/scripts/systems/maaxboard1
@@ -53,3 +53,11 @@ MaxCLK_maaxboard1() {
 Sel4Plat_maaxboard1() {
     echo "maaxboard"
 }
+
+PXELinux_maaxboard1() {
+    echo "yes"
+}
+
+DTB_maaxboard1() {
+    echo "yes"
+}

--- a/scripts/systems/makatea
+++ b/scripts/systems/makatea
@@ -48,3 +48,11 @@ MaxCLK_makatea() {
 Sel4Plat_makatea() {
     echo "pc99:skylake"
 }
+
+PXELinux_makatea() {
+    echo "no"
+}
+
+DTB_makatea() {
+    echo "no"
+}

--- a/scripts/systems/odroidc2
+++ b/scripts/systems/odroidc2
@@ -53,3 +53,11 @@ MaxCLK_odroidc2() {
 Sel4Plat_odroidc2() {
     echo "odroidc2"
 }
+
+PXELinux_odroidc2() {
+    echo "yes"
+}
+
+DTB_odroidc2() {
+    echo "yes"
+}

--- a/scripts/systems/odroidc4_1
+++ b/scripts/systems/odroidc4_1
@@ -53,3 +53,11 @@ MaxCLK_odroidc4_1() {
 Sel4Plat_odroidc4_1() {
     echo "odroidc4"
 }
+
+PXELinux_odroidc4_1() {
+    echo "yes"
+}
+
+DTB_odroidc4_1() {
+    echo "yes"
+}

--- a/scripts/systems/odroidc4_2
+++ b/scripts/systems/odroidc4_2
@@ -53,3 +53,11 @@ MaxCLK_odroidc4_2() {
 Sel4Plat_odroidc4_2() {
     echo "odroidc4"
 }
+
+PXELinux_odroidc4_2() {
+    echo "yes"
+}
+
+DTB_odroidc4_2() {
+    echo "yes"
+}

--- a/scripts/systems/odroidxu4_1
+++ b/scripts/systems/odroidxu4_1
@@ -48,3 +48,11 @@ MaxCLK_odroidxu4_1() {
 Sel4Plat_odroidxu4_1() {
     echo "exynos5:exynos5422"
 }
+
+PXELinux_odroidxu4_1() {
+    echo "no"
+}
+
+DTB_odroidxu4_1() {
+    echo "no"
+}

--- a/scripts/systems/odroidxu4_2
+++ b/scripts/systems/odroidxu4_2
@@ -48,3 +48,11 @@ MaxCLK_odroidxu4_2() {
 Sel4Plat_odroidxu4_2() {
     echo "exynos5:exynos5422"
 }
+
+PXELinux_odroidxu4_2() {
+    echo "no"
+}
+
+DTB_odroidxu4_2() {
+    echo "no"
+}

--- a/scripts/systems/pi4B
+++ b/scripts/systems/pi4B
@@ -48,3 +48,11 @@ MaxCLK_pi4B() {
 Sel4Plat_pi4B() {
     echo "rpi4"
 }
+
+PXELinux_pi4B() {
+    echo "no"
+}
+
+DTB_pi4B() {
+    echo "no"
+}

--- a/scripts/systems/rockpro64a
+++ b/scripts/systems/rockpro64a
@@ -48,3 +48,11 @@ MaxCLK_rockpro64a() {
 Sel4Plat_rockpro64a() {
     echo "rockpro64"
 }
+
+PXELinux_rockpro64a() {
+    echo "no"
+}
+
+DTB_rockpro64a() {
+    echo "no"
+}

--- a/scripts/systems/rpi3
+++ b/scripts/systems/rpi3
@@ -48,3 +48,11 @@ MaxCLK_rpi3() {
 Sel4Plat_rpi3() {
     echo "bcm2837:rpi3"
 }
+
+PXELinux_rpi3() {
+    echo "no"
+}
+
+DTB_rpi3() {
+    echo "no"
+}

--- a/scripts/systems/sabre
+++ b/scripts/systems/sabre
@@ -48,3 +48,11 @@ MaxCLK_sabre() {
 Sel4Plat_sabre() {
     echo "imx6:sabre"
 }
+
+PXELinux_sabre() {
+    echo "no"
+}
+
+DTB_sabre() {
+    echo "no"
+}

--- a/scripts/systems/sabre2
+++ b/scripts/systems/sabre2
@@ -48,3 +48,11 @@ MaxCLK_sabre2() {
 Sel4Plat_sabre2() {
     echo "imx6:sabre"
 }
+
+PXELinux_sabre2() {
+    echo "no"
+}
+
+DTB_sabre2() {
+    echo "no"
+}

--- a/scripts/systems/sabre4
+++ b/scripts/systems/sabre4
@@ -48,3 +48,11 @@ MaxCLK_sabre4() {
 Sel4Plat_sabre4() {
     echo "imx6:sabre"
 }
+
+PXELinux_sabre4() {
+    echo "no"
+}
+
+DTB_sabre4() {
+    echo "no"
+}

--- a/scripts/systems/skylake
+++ b/scripts/systems/skylake
@@ -48,3 +48,11 @@ MaxCLK_skylake() {
 Sel4Plat_skylake() {
     echo "pc99:skylake"
 }
+
+PXELinux_skylake() {
+    echo "no"
+}
+
+DTB_skylake() {
+    echo "no"
+}

--- a/scripts/systems/skylake2
+++ b/scripts/systems/skylake2
@@ -48,3 +48,11 @@ MaxCLK_skylake2() {
 Sel4Plat_skylake2() {
     echo "pc99:skylake"
 }
+
+PXELinux_skylake2() {
+    echo "no"
+}
+
+DTB_skylake2() {
+    echo "no"
+}

--- a/scripts/systems/skylake3
+++ b/scripts/systems/skylake3
@@ -48,3 +48,11 @@ MaxCLK_skylake3() {
 Sel4Plat_skylake3() {
     echo "pc99:skylake"
 }
+
+PXELinux_skylake3() {
+    echo "no"
+}
+
+DTB_skylake3() {
+    echo "no"
+}

--- a/scripts/systems/star64
+++ b/scripts/systems/star64
@@ -53,3 +53,11 @@ MaxCLK_star64() {
 Sel4Plat_star64() {
     echo "star64"
 }
+
+PXELinux_star64() {
+    echo "yes"
+}
+
+DTB_star64() {
+    echo "yes"
+}

--- a/scripts/systems/tardec2
+++ b/scripts/systems/tardec2
@@ -48,3 +48,11 @@ MaxCLK_tardec2() {
 Sel4Plat_tardec2() {
     echo "pc99"
 }
+
+PXELinux_tardec2() {
+    echo "no"
+}
+
+DTB_tardec2() {
+    echo "no"
+}

--- a/scripts/systems/tqma
+++ b/scripts/systems/tqma
@@ -48,3 +48,11 @@ MaxCLK_tqma() {
 Sel4Plat_tqma() {
     echo "tqma8xqp1gb"
 }
+
+PXELinux_tqma() {
+    echo "no"
+}
+
+DTB_tqma() {
+    echo "no"
+}

--- a/scripts/systems/tx1a
+++ b/scripts/systems/tx1a
@@ -48,3 +48,11 @@ MaxCLK_tx1a() {
 Sel4Plat_tx1a() {
     echo "tx1"
 }
+
+PXELinux_tx1a() {
+    echo "no"
+}
+
+DTB_tx1a() {
+    echo "no"
+}

--- a/scripts/systems/tx2a
+++ b/scripts/systems/tx2a
@@ -53,3 +53,11 @@ MaxCLK_tx2a() {
 Sel4Plat_tx2a() {
     echo "tx2"
 }
+
+PXELinux_tx2a() {
+    echo "yes"
+}
+
+DTB_tx2a() {
+    echo "yes"
+}

--- a/scripts/systems/tx2b
+++ b/scripts/systems/tx2b
@@ -48,3 +48,11 @@ MaxCLK_tx2b() {
 Sel4Plat_tx2b() {
     echo "tx2"
 }
+
+PXELinux_tx2b() {
+    echo "no"
+}
+
+DTB_tx2b() {
+    echo "no"
+}

--- a/scripts/systems/vb_105
+++ b/scripts/systems/vb_105
@@ -48,3 +48,11 @@ MaxCLK_vb_105() {
 Sel4Plat_vb_105() {
     echo "pc99:skylake"
 }
+
+PXELinux_vb_105() {
+    echo "yes"
+}
+
+DTB_vb_105() {
+    echo "no"
+}

--- a/scripts/systems/xavier_1
+++ b/scripts/systems/xavier_1
@@ -48,3 +48,11 @@ MaxCLK_xavier_1() {
 Sel4Plat_xavier_1() {
     echo "xavier"
 }
+
+PXELinux_xavier_1() {
+    echo "no"
+}
+
+DTB_xavier_1() {
+    echo "no"
+}

--- a/scripts/systems/zcu102
+++ b/scripts/systems/zcu102
@@ -48,3 +48,11 @@ MaxCLK_zcu102() {
 Sel4Plat_zcu102() {
     echo "zynqmp"
 }
+
+PXELinux_zcu102() {
+    echo "no"
+}
+
+DTB_zcu102() {
+    echo "no"
+}

--- a/scripts/systems/zcu102_2
+++ b/scripts/systems/zcu102_2
@@ -48,3 +48,11 @@ MaxCLK_zcu102_2() {
 Sel4Plat_zcu102_2() {
     echo "zynqmp"
 }
+
+PXELinux_zcu102_2() {
+    echo "no"
+}
+
+DTB_zcu102_2() {
+    echo "no"
+}

--- a/scripts/systems/zcu106
+++ b/scripts/systems/zcu106
@@ -48,3 +48,11 @@ MaxCLK_zcu106() {
 Sel4Plat_zcu106() {
     echo "zynqmp"
 }
+
+PXELinux_zcu106() {
+    echo "no"
+}
+
+DTB_zcu106() {
+    echo "no"
+}


### PR DESCRIPTION
Added support for machines which boot Linux remotely using dtbs to have dtbs supplied to the machine queue script rather than using the default one on tftp. Also added a command to display which boards are capable of remote booting Linux and which will accept dtbs, and error messages if you try to use these features on boards that don't support them.