### PR TITLE
Added Linux netbooting support for zcu102s

### DIFF
--- a/scripts/systems/zcu102
+++ b/scripts/systems/zcu102
@@ -6,7 +6,12 @@ if [ "${SCRIPT_PATH}" = "" ]; then
 fi
 
 SystemNumFiles_zcu102() {
-    echo 1
+    if [ "$1" = '-L' ]
+    then
+        echo 2
+    else
+        echo 1
+    fi
 }
 
 SystemName_zcu102() {
@@ -50,9 +55,9 @@ Sel4Plat_zcu102() {
 }
 
 PXELinux_zcu102() {
-    echo "no"
+    echo "yes"
 }
 
 DTB_zcu102() {
-    echo "no"
+    echo "yes"
 }

--- a/scripts/systems/zcu102_2
+++ b/scripts/systems/zcu102_2
@@ -6,7 +6,12 @@ if [ "${SCRIPT_PATH}" = "" ]; then
 fi
 
 SystemNumFiles_zcu102_2() {
-    echo 1
+    if [ "$1" = '-L' ]
+    then
+        echo 2
+    else
+        echo 1
+    fi
 }
 
 SystemName_zcu102_2() {
@@ -50,9 +55,9 @@ Sel4Plat_zcu102_2() {
 }
 
 PXELinux_zcu102_2() {
-    echo "no"
+    echo "yes"
 }
 
 DTB_zcu102_2() {
-    echo "no"
+    echo "yes"
 }


### PR DESCRIPTION
Added support for zcu102 and zcu102_2 to boot linux images provided by the user, optionally with a user-supplied dtb. These are the changes necessary for the client machine queue scripts to accept those files.