### PR TITLE
Added note about the dumpall command to mq sem's help

### DIFF
--- a/scripts/lock
+++ b/scripts/lock
@@ -174,6 +174,7 @@ CancelWait() {
 
 UserLockUsage() {
     echo "$0 sem -signal|-wait|-cancel|-info SYSTEM [-f] [-w retry-time] [-t retry-count] [-k LOCK_KEY]"
+    echo "$0 sem dumpall"
     echo
     echo "   Manually manipulate locks for machines. The lock for each system"
     echo "   can be acquired or released."
@@ -193,6 +194,7 @@ UserLockUsage() {
     echo " -f               Forcefully releases a lock even if you are not the owner"
     echo " -k LOCK_KEY      Set a key inside the lock"
     echo " -T timeout       Allow lock to be reclaimed after timeout seconds"
+    echo " dumpall          Prints all currently locked systems"
     echo
 }
 


### PR DESCRIPTION
mq supports viewing all currently locked systems with `mq sem dumpall`. I added a note about `dumpall` to sem's help output so the existence of the option will be more apparent; previously it could only be found by reading the code.