### PR TITLE
Added note about dumpall command to sem's help

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,7 @@ Options:
 - `-t` _RETRIES_  Number of retries to perform for acquiring the lock (default -1)
 
 
-`mq sem -signal|-wait|-cancel|-info `_<system>_` [-f] [-w `_retry-time_` ] [-t `_retry-count_` ] [-k `_LOCK_\__KEY_` ] [-T` _timeout_`]`
-`mq sem dumpall`
+`mq sem dumpall|-signal|-wait|-cancel|-info `_<system>_` [-f] [-w `_retry-time_` ] [-t `_retry-count_` ] [-k `_LOCK_\__KEY_` ] [-T` _timeout_`]`
 
    Manually manipulate locks for machines. The lock for each system
    can be acquired or released.
@@ -119,7 +118,7 @@ Options:
 - `-f`               Forcefully releases a lock even if you are not the owner
 - `-k` _LOCK\_KEY_      Set a key inside the lock
 - `-T` _timeout_       Allow lock to be reclaimed after _timeout_ seconds
-- `dumpall             Prints all currently locked systems`
+- `dumpall`            Prints all currently locked systems
 
 `mq systems [help|simple]`
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Options:
 
 
 `mq sem -signal|-wait|-cancel|-info `_<system>_` [-f] [-w `_retry-time_` ] [-t `_retry-count_` ] [-k `_LOCK_\__KEY_` ] [-T` _timeout_`]`
+`mq sem dumpall`
 
    Manually manipulate locks for machines. The lock for each system
    can be acquired or released.
@@ -118,6 +119,7 @@ Options:
 - `-f`               Forcefully releases a lock even if you are not the owner
 - `-k` _LOCK\_KEY_      Set a key inside the lock
 - `-T` _timeout_       Allow lock to be reclaimed after _timeout_ seconds
+- `dumpall             Prints all currently locked systems`
 
 `mq systems [help|simple]`
 

--- a/bash_mq_completion.sh
+++ b/bash_mq_completion.sh
@@ -16,7 +16,7 @@ _mq_completion() {
     case "${COMP_WORDS[1]}" in
       sem)
         if [ "$COMP_CWORD" -eq "2" ]; then
-          COMPREPLY=($(compgen -W "-signal -wait -info -mr-info -cancel" -- "${cur}"))
+          COMPREPLY=($(compgen -W "-signal -wait -info -mr-info -cancel dumpall" -- "${cur}"))
         elif [ "$COMP_CWORD" -eq "3" ]; then
           COMPREPLY=($(compgen -W "$(_mq_systems)" -- "${cur}"))
         elif [ "$COMP_CWORD" -eq "4" ]; then

--- a/scripts/lock
+++ b/scripts/lock
@@ -174,6 +174,7 @@ CancelWait() {
 
 UserLockUsage() {
     echo "$0 sem -signal|-wait|-cancel|-info SYSTEM [-f] [-w retry-time] [-t retry-count] [-k LOCK_KEY]"
+    echo "$0 sem dumpall"
     echo
     echo "   Manually manipulate locks for machines. The lock for each system"
     echo "   can be acquired or released."
@@ -193,6 +194,7 @@ UserLockUsage() {
     echo " -f               Forcefully releases a lock even if you are not the owner"
     echo " -k LOCK_KEY      Set a key inside the lock"
     echo " -T timeout       Allow lock to be reclaimed after timeout seconds"
+    echo " dumpall          Prints all currently locked systems"
     echo
 }
 


### PR DESCRIPTION
Previously the dumpall command under 'sem' could only be found by reading the code. This change adds mention of it to sem's help output.