### PR TITLE
Improved pool support

### DIFF
--- a/scripts/enqueue
+++ b/scripts/enqueue
@@ -292,9 +292,13 @@ Enqueue() {
 
         lock_tries=0
 
+        # Need to use a different name so as not to collide with other local variables
+        loop_retries="$total_retries"
+        loop_period="$retry_period"
+
         # Loop until total_retries + 1 because we want to make the initial attempt,
         # and then retry the correct number of times
-        while [ "${total_retries}" -eq -1 -o "${lock_tries}" -lt "$((${total_retries}+1))" ] ; do
+        while [ "${loop_retries}" -eq -1 -o "${lock_tries}" -lt "$((${loop_retries}+1))" ] ; do
 
             # Loop through and try all systems in the pool.
             for system in $(Systems_"${pool}"); do
@@ -310,7 +314,7 @@ Enqueue() {
 
             lock_tries=$(($lock_tries+1))
 
-            sleep "${retry_period}"
+            sleep "${loop_period}"
 
         done
 

--- a/scripts/enqueue
+++ b/scripts/enqueue
@@ -109,6 +109,7 @@ EnqueueOneSystem() {
             # Locking failed; reset the trap
             # The outer Enqueue function will handle reporting the lock failure
             trap "exit 1" ${SIGNALS}
+            return 1
         fi
     fi
 }
@@ -291,7 +292,9 @@ Enqueue() {
 
         lock_tries=0
 
-        while [ "${total_retries}" -eq -1 ] || [ "${lock_tries}" -lt "${total_retries}" ] ; do
+        # Loop until total_retries + 1 because we want to make the initial attempt,
+        # and then retry the correct number of times
+        while [ "${total_retries}" -eq -1 -o "${lock_tries}" -lt "$((${total_retries}+1))" ] ; do
 
             # Loop through and try all systems in the pool.
             for system in $(Systems_"${pool}"); do
@@ -323,6 +326,4 @@ Enqueue() {
         PoolList
         exit 1
     fi
-
-    exit $ret
 }

--- a/scripts/enqueue
+++ b/scripts/enqueue
@@ -66,12 +66,6 @@ EnqueueOneSystem() {
             return 1
         fi
         lockkey=$(LockGetKey "${system}")
-        if [ "${lockkey}" = "0" -a  "${key}" = "0" ]
-        then
-            # No key on lock or user is fine
-            echo "Attempting to grab lock you already own. Please explicitly release"
-            return 1
-        fi
         if [ "${lockkey}" != "${key}" ]
         then
             echo "Failed to run because you said you own the lock (-n flag), but you gave the wrong key!"

--- a/scripts/enqueue
+++ b/scripts/enqueue
@@ -303,6 +303,8 @@ Enqueue() {
 
             lock_tries=$(($lock_tries+1))
 
+            sleep "${retry_period}"
+
         done
 
     else

--- a/scripts/enqueue
+++ b/scripts/enqueue
@@ -9,6 +9,108 @@ fi
 # 'if anything at all happens try and shut down our job cleanly' approach
 SIGNALS="INT TERM HUP QUIT KILL PIPE"
 
+
+# 1      2            3             4   5            6          7                  8        9
+# system retry_period total_retries key no_lock_mods completion completion_timeout errortxt logfile keep_alive linux dtbflag file_count files
+
+EnqueueOneSystem() {
+    
+    system="$1"
+    retry_period="$2"
+    total_retries="$3"
+    key="$4"
+    no_lock_mods="$5"
+    completion="$6"
+    completion_timeout="$7"
+    errortxt="$8"
+    logfile="$9"
+    shift 9
+    keep_alive="$1"
+    linux="$2"
+    dtbflag="$3"
+    file_count="$4"
+    files="$5"
+
+
+    if [ ! -z "${linux}" ]; then
+        if ! SystemBootsLinuxPXE "${system}" ; then
+            echo "System cannot boot Linux over the network."
+            exit 1
+        fi
+    fi
+
+    if [ ! -z "$dtbflag" ]; then
+        if ! SystemAcceptsDtb "${system}" ; then
+            echo "System does not accept a dtb"
+            exit 1
+        fi
+    fi
+
+    if [ ! -z "$dtbflag" ] && [ -z "$linux" ]; then
+        echo "A dtb may only be supplied when booting a linux image over the network."
+        exit 1
+    fi
+
+    # Check that the number of files specified is correct
+    if [ "$interact" != "-r" ] ; then
+        if ! SystemCorrectNumberOfFiles ${linux} "${system}" "${file_count}"; then
+            echo "Wrong number of files specified for system ${system}"
+            exit 1
+        fi
+    fi
+
+    if ${no_lock_mods} ; then
+        if ! LockIOwn "${system}"; then
+            echo "Failed to run because you said you own the lock (-n flag), but you don't!"
+            LockSystemPrintInfo "${system}"
+            exit 1
+        fi
+    else
+        echo "Acquiring lock for ${system}"
+
+        # Print out potentially useful information to the user about
+        # the current status of the lock
+        LockSystemPrintInfo "${system}"
+
+        # We can setup the trap early as we check if we actually own the
+        # the lock before releasing it
+        trap "UnlockSystem \"${system}\" 0 \"${key}\"; exit 1" ${SIGNALS}
+
+        if ! LockSystem "${system}" "${retry_period}" "${total_retries}" "${key}"; then
+            echo "Failed to acquire lock for system (${system})"
+            exit 2
+        fi
+    fi
+
+    echo "Lock acquired, we are allowed to run"
+    local ret=0
+
+    if [ "${interact}" = "-r" ]; then
+        echo "This is a reservation. You now own ${system} and"
+        echo "can do what you want. Press ctrl+d or enter here when done"
+        read line
+        echo "Attempting to power off machine now that you are done"
+        SystemPowerOff "${system}"
+    else
+        # Run the image. 'files' is deliberately not in quotes so the multiple
+        # files expands to multiple arguments
+        # 'dtbflag' is deliberately not in quotes so it expands to multiple
+        # parameters '-b' and 'my.dtb'
+        # 'linux' is deliberately not in quotes so it will not create an empty
+        # parameter if the flag is not set
+        SystemRunImage "${system}" "${completion}" "${completion_timeout}" "${errortxt}" "${logfile}" "${keep_alive}" ${linux} ${dtbflag} $files
+        ret=$?
+    fi
+
+    if ! ${no_lock_mods} ; then
+        UnlockSystem "${system}" 0 "${key}"
+        trap "exit 1" ${SIGNALS}
+    fi
+
+    exit $ret
+
+}
+
 EnqueueUsage() {
     echo "$0 run -r|-c <string> -l logfile -s system [-w retry-time] [-t retry-count] [-n] [-a] [-d timeout] [-e <string>] [-k <string>] [-L] [-b <file>] -f file1 -f file2 .. -f filen"
     echo
@@ -159,97 +261,60 @@ Enqueue() {
         exit 1
     fi
 
+
+    local ret=0
+
     # Verify the requested system exists
-    if ! IsSystemValid "${system}" ; then
-        # If it's not a system, is it a pool?
-        if ! IsPoolValid "${system}" ; then
-            echo "System or pool '$system' does not exist. Valid systems are"
-            SystemList
-            echo "Valid pools are"
-            PoolList
-            exit 1
-        fi
-        # Select a system from the pool
+    if IsSystemValid "${system}" ; then
+
+        # Everything is quoted so we'll pass on the exact same number of parameters every time
+        EnqueueOneSystem "${system}" "${retry_period}" "${total_retries}" "${key}" "${no_lock_mods}" "${completion}" "${completion_timeout}" "${errortxt}" "${logfile}" "${keep_alive}" "${linux}" "${dtbflag}" "${file_count}" "${files}"
+
+        ret=$?
+
+    # If it's not a system, is it a pool?
+    elif IsPoolValid "${system}" ; then
         pool=${system}
-        system=$(GetRandomSystemFromPool_"${pool}")
-        echo "Selecting system '${system}' from pool '${pool}'"
-    fi
 
-    if [ ! -z "${linux}" ]; then
-        if ! SystemBootsLinuxPXE "${system}" ; then
-            echo "System cannot boot Linux over the network."
-            exit 1
-        fi
-    fi
+        # When attempting to lock a pool, we use the retry time and retry count
+        # given by the user for how often we attempt locking on the whole pool,
+        # not for lock attempts on a specific system.
+        # Each time the user-configured period elapses, we try (but do not wait
+        # on) locking each system in the pool.
 
-    if [ ! -z "$dtbflag" ]; then
-        if ! SystemAcceptsDtb "${system}" ; then
-            echo "System does not accept a dtb"
-            exit 1
-        fi
-    fi
+        lock_tries=0
 
-    if [ ! -z "$dtbflag" ] && [ -z "$linux" ]; then
-        echo "A dtb may only be supplied when booting a linux image over the network."
+        # TODO obviously broken, sh doesn't do maths
+        while "${total_retries}" == -1 ||  "${lock_tries}" < "${total_retries}" ; do
+
+
+            # Loop through and try all systems in the pool.
+            for system in $(Systems_"${pool}"); do
+
+                # Note we do not retry and give a small retry period (which is unused)
+                # We only want to attempt locking, not wait on it
+                EnqueueOneSystem "${system}" "1" "0" "${key}" "${no_lock_mods}" "${completion}" "${completion_timeout}" "${errortxt}" "${logfile}" "${keep_alive}" "${linux}" "${dtbflag}" "${file_count}" "${files}"
+
+                ret=$?
+
+                if [ "${ret}" == 0 ]; then
+                    # Running succeeded on a board
+                    exit "${ret}"
+                fi
+            done
+
+            lock_tries=$lock_tries+1
+
+        done
+
+    else
+
+        echo "System or pool '$system' does not exist. Valid systems are"
+        SystemList
+        echo "Valid pools are"
+        PoolList
         exit 1
     fi
 
-    # Check that the number of files specified is correct
-    if [ "$interact" != "-r" ] ; then
-        if ! SystemCorrectNumberOfFiles ${linux} "${system}" "${file_count}"; then
-            echo "Wrong number of files specified for system ${system}"
-            exit 1
-        fi
-    fi
-
-    if ${no_lock_mods} ; then
-        if ! LockIOwn "${system}"; then
-            echo "Failed to run because you said you own the lock (-n flag), but you don't!"
-            LockSystemPrintInfo "${system}"
-            exit 1
-        fi
-    else
-        echo "Acquiring lock for ${system}"
-
-        # Print out potentially useful information to the user about
-        # the current status of the lock
-        LockSystemPrintInfo "${system}"
-
-        # We can setup the trap early as we check if we actually own the
-        # the lock before releasing it
-        trap "UnlockSystem \"${system}\" 0 \"${key}\"; exit 1" ${SIGNALS}
-
-        if ! LockSystem "${system}" "${retry_period}" "${total_retries}" "${key}"; then
-            echo "Failed to acquire lock for system (${system})"
-            exit 2
-        fi
-    fi
-
-    echo "Lock acquired, we are allowed to run"
-    local ret=0
-
-    if [ "${interact}" = "-r" ]; then
-        echo "This is a reservation. You now own ${system} and"
-        echo "can do what you want. Press ctrl+d or enter here when done"
-        read line
-        echo "Attempting to power off machine now that you are done"
-        SystemPowerOff "${system}"
-    else
-        # Run the image. 'files' is deliberately not in quotes so the multiple
-        # files expands to multiple arguments
-        # 'dtbflag' is deliberately not in quotes so it expands to multiple
-        # parameters '-b' and 'my.dtb'
-        # 'linux' is deliberately not in quotes so it will not create an empty
-        # parameter if the flag is not set
-        SystemRunImage "${system}" "${completion}" "${completion_timeout}" "${errortxt}" "${logfile}" "${keep_alive}" ${linux} ${dtbflag} $files
-        ret=$?
-    fi
-
-    if ! ${no_lock_mods} ; then
-        UnlockSystem "${system}" 0 "${key}"
-        trap "exit 1" ${SIGNALS}
-    fi
-
     exit $ret
-
 }

--- a/scripts/enqueue
+++ b/scripts/enqueue
@@ -34,14 +34,14 @@ EnqueueOneSystem() {
 
     if [ ! -z "${linux}" ]; then
         if ! SystemBootsLinuxPXE "${system}" ; then
-            echo "System cannot boot Linux over the network."
+            echo "System ${system} cannot boot Linux over the network."
             exit 1
         fi
     fi
 
     if [ ! -z "$dtbflag" ]; then
         if ! SystemAcceptsDtb "${system}" ; then
-            echo "System does not accept a dtb"
+            echo "System ${system} does not accept a dtb"
             exit 1
         fi
     fi
@@ -76,39 +76,41 @@ EnqueueOneSystem() {
         # the lock before releasing it
         trap "UnlockSystem \"${system}\" 0 \"${key}\"; exit 1" ${SIGNALS}
 
-        if ! LockSystem "${system}" "${retry_period}" "${total_retries}" "${key}"; then
-            echo "Failed to acquire lock for system (${system})"
-            exit 2
+        if LockSystem "${system}" "${retry_period}" "${total_retries}" "${key}"; then
+
+            echo "Lock acquired, we are allowed to run"
+            local ret=0
+
+            if [ "${interact}" = "-r" ]; then
+                echo "This is a reservation. You now own ${system} and"
+                echo "can do what you want. Press ctrl+d or enter here when done"
+                read line
+                echo "Attempting to power off machine now that you are done"
+                SystemPowerOff "${system}"
+            else
+                # Run the image. 'files' is deliberately not in quotes so the multiple
+                # files expands to multiple arguments
+                # 'dtbflag' is deliberately not in quotes so it expands to multiple
+                # parameters '-b' and 'my.dtb'
+                # 'linux' is deliberately not in quotes so it will not create an empty
+                # parameter if the flag is not set
+                SystemRunImage "${system}" "${completion}" "${completion_timeout}" "${errortxt}" "${logfile}" "${keep_alive}" ${linux} ${dtbflag} $files
+                ret=$?
+            fi
+
+            if ! ${no_lock_mods} ; then
+                UnlockSystem "${system}" 0 "${key}"
+                trap "exit 1" ${SIGNALS}
+            fi
+
+            exit $ret
+
+        else
+            # Locking failed; reset the trap
+            # The outer Enqueue function will handle reporting the lock failure
+            trap "exit 1" ${SIGNALS}
         fi
     fi
-
-    echo "Lock acquired, we are allowed to run"
-    local ret=0
-
-    if [ "${interact}" = "-r" ]; then
-        echo "This is a reservation. You now own ${system} and"
-        echo "can do what you want. Press ctrl+d or enter here when done"
-        read line
-        echo "Attempting to power off machine now that you are done"
-        SystemPowerOff "${system}"
-    else
-        # Run the image. 'files' is deliberately not in quotes so the multiple
-        # files expands to multiple arguments
-        # 'dtbflag' is deliberately not in quotes so it expands to multiple
-        # parameters '-b' and 'my.dtb'
-        # 'linux' is deliberately not in quotes so it will not create an empty
-        # parameter if the flag is not set
-        SystemRunImage "${system}" "${completion}" "${completion_timeout}" "${errortxt}" "${logfile}" "${keep_alive}" ${linux} ${dtbflag} $files
-        ret=$?
-    fi
-
-    if ! ${no_lock_mods} ; then
-        UnlockSystem "${system}" 0 "${key}"
-        trap "exit 1" ${SIGNALS}
-    fi
-
-    exit $ret
-
 }
 
 EnqueueUsage() {
@@ -268,9 +270,14 @@ Enqueue() {
     if IsSystemValid "${system}" ; then
 
         # Everything is quoted so we'll pass on the exact same number of parameters every time
-        EnqueueOneSystem "${system}" "${retry_period}" "${total_retries}" "${key}" "${no_lock_mods}" "${completion}" "${completion_timeout}" "${errortxt}" "${logfile}" "${keep_alive}" "${linux}" "${dtbflag}" "${file_count}" "${files}"
+        if EnqueueOneSystem "${system}" "${retry_period}" "${total_retries}" "${key}" "${no_lock_mods}" "${completion}" "${completion_timeout}" "${errortxt}" "${logfile}" "${keep_alive}" "${linux}" "${dtbflag}" "${file_count}" "${files}" ; then
+            ret=$?
+            exit "${ret}"
+        fi
 
-        ret=$?
+        # If we get here, the enqueing failed
+        echo "Failed to acquire lock for system (${system})"
+        exit 2
 
     # If it's not a system, is it a pool?
     elif IsPoolValid "${system}" ; then
@@ -303,6 +310,10 @@ Enqueue() {
             sleep "${retry_period}"
 
         done
+
+        # If we get here, we've exhausted the specified number of retries
+        echo "Failed to acquire lock for any system in pool (${pool})"
+        exit 2
 
     else
 

--- a/scripts/enqueue
+++ b/scripts/enqueue
@@ -301,6 +301,8 @@ Enqueue() {
             # Loop through and try all systems in the pool.
             for system in $(Systems_"${pool}"); do
 
+                echo "Attempting system ${system} in pool ${pool}"
+
                 # Note we do not retry and give a small retry period (which is unused)
                 # We only want to attempt locking, not wait on it
                 if EnqueueOneSystem "${system}" "1" "0" "${key}" "${no_lock_mods}" "${completion}" "${completion_timeout}" "${errortxt}" "${logfile}" "${keep_alive}" "${linux}" "${dtbflag}" "${file_count}" "${files}" ; then
@@ -308,7 +310,10 @@ Enqueue() {
                     ret=$?
                     exit "${ret}"
                 fi
+
             done
+
+            echo "Done attempting system ${system} in pool ${pool}"
 
             lock_tries=$(($lock_tries+1))
 

--- a/scripts/enqueue
+++ b/scripts/enqueue
@@ -284,9 +284,7 @@ Enqueue() {
 
         lock_tries=0
 
-        # TODO obviously broken, sh doesn't do maths
-        while "${total_retries}" == -1 ||  "${lock_tries}" < "${total_retries}" ; do
-
+        while [ "${total_retries}" -eq -1 ] || [ "${lock_tries}" -lt "${total_retries}" ] ; do
 
             # Loop through and try all systems in the pool.
             for system in $(Systems_"${pool}"); do
@@ -303,7 +301,7 @@ Enqueue() {
                 fi
             done
 
-            lock_tries=$lock_tries+1
+            lock_tries=$(($lock_tries+1))
 
         done
 

--- a/scripts/enqueue
+++ b/scripts/enqueue
@@ -63,7 +63,7 @@ EnqueueOneSystem() {
         if ! LockIOwn "${system}"; then
             echo "Failed to run because you said you own the lock (-n flag), but you don't!"
             LockSystemPrintInfo "${system}"
-            exit 1
+            return 1
         fi
     else
         echo "Acquiring lock for ${system}"
@@ -76,42 +76,40 @@ EnqueueOneSystem() {
         # the lock before releasing it
         trap "UnlockSystem \"${system}\" 0 \"${key}\"; exit 1" ${SIGNALS}
 
-        if LockSystem "${system}" "${retry_period}" "${total_retries}" "${key}"; then
-
-            echo "Lock acquired, we are allowed to run"
-            local ret=0
-
-            if [ "${interact}" = "-r" ]; then
-                echo "This is a reservation. You now own ${system} and"
-                echo "can do what you want. Press ctrl+d or enter here when done"
-                read line
-                echo "Attempting to power off machine now that you are done"
-                SystemPowerOff "${system}"
-            else
-                # Run the image. 'files' is deliberately not in quotes so the multiple
-                # files expands to multiple arguments
-                # 'dtbflag' is deliberately not in quotes so it expands to multiple
-                # parameters '-b' and 'my.dtb'
-                # 'linux' is deliberately not in quotes so it will not create an empty
-                # parameter if the flag is not set
-                SystemRunImage "${system}" "${completion}" "${completion_timeout}" "${errortxt}" "${logfile}" "${keep_alive}" ${linux} ${dtbflag} $files
-                ret=$?
-            fi
-
-            if ! ${no_lock_mods} ; then
-                UnlockSystem "${system}" 0 "${key}"
-                trap "exit 1" ${SIGNALS}
-            fi
-
-            exit $ret
-
-        else
+        if ! LockSystem "${system}" "${retry_period}" "${total_retries}" "${key}"; then
             # Locking failed; reset the trap
             # The outer Enqueue function will handle reporting the lock failure
             trap "exit 1" ${SIGNALS}
             return 1
         fi
     fi
+
+    echo "Lock acquired, we are allowed to run"
+    local ret=0
+
+    if [ "${interact}" = "-r" ]; then
+        echo "This is a reservation. You now own ${system} and"
+        echo "can do what you want. Press ctrl+d or enter here when done"
+        read line
+        echo "Attempting to power off machine now that you are done"
+        SystemPowerOff "${system}"
+    else
+        # Run the image. 'files' is deliberately not in quotes so the multiple
+        # files expands to multiple arguments
+        # 'dtbflag' is deliberately not in quotes so it expands to multiple
+        # parameters '-b' and 'my.dtb'
+        # 'linux' is deliberately not in quotes so it will not create an empty
+        # parameter if the flag is not set
+        SystemRunImage "${system}" "${completion}" "${completion_timeout}" "${errortxt}" "${logfile}" "${keep_alive}" ${linux} ${dtbflag} $files
+        ret=$?
+    fi
+
+    if ! ${no_lock_mods} ; then
+        UnlockSystem "${system}" 0 "${key}"
+        trap "exit 1" ${SIGNALS}
+    fi
+
+    exit $ret
 }
 
 EnqueueUsage() {

--- a/scripts/enqueue
+++ b/scripts/enqueue
@@ -291,12 +291,9 @@ Enqueue() {
 
                 # Note we do not retry and give a small retry period (which is unused)
                 # We only want to attempt locking, not wait on it
-                EnqueueOneSystem "${system}" "1" "0" "${key}" "${no_lock_mods}" "${completion}" "${completion_timeout}" "${errortxt}" "${logfile}" "${keep_alive}" "${linux}" "${dtbflag}" "${file_count}" "${files}"
-
-                ret=$?
-
-                if [ "${ret}" == 0 ]; then
+                if EnqueueOneSystem "${system}" "1" "0" "${key}" "${no_lock_mods}" "${completion}" "${completion_timeout}" "${errortxt}" "${logfile}" "${keep_alive}" "${linux}" "${dtbflag}" "${file_count}" "${files}" ; then
                     # Running succeeded on a board
+                    ret=$?
                     exit "${ret}"
                 fi
             done

--- a/scripts/enqueue
+++ b/scripts/enqueue
@@ -65,6 +65,19 @@ EnqueueOneSystem() {
             LockSystemPrintInfo "${system}"
             return 1
         fi
+        lockkey=$(LockGetKey "${system}")
+        if [ "${lockkey}" = "0" -a  "${key}" = "0" ]
+        then
+            # No key on lock or user is fine
+            echo "Attempting to grab lock you already own. Please explicitly release"
+            return 1
+        fi
+        if [ "${lockkey}" != "${key}" ]
+        then
+            echo "Failed to run because you said you own the lock (-n flag), but you gave the wrong key!"
+            return 2
+        fi
+
     else
         echo "Acquiring lock for ${system}"
 

--- a/scripts/lock
+++ b/scripts/lock
@@ -351,6 +351,8 @@ UserLock() {
                     # Loop through and try all systems in the pool.
                     for system in $(Systems_"${pool}"); do
 
+                        echo "Attempting system ${system} in pool ${pool}"
+
                         # Note we do not retry the individual lock attempt,
                         # and give only a small retry period (which is unused)
                         # We only want to attempt locking, not wait on it
@@ -362,6 +364,8 @@ UserLock() {
                             exit "${ret}"
                         fi
                     done
+
+                    echo "Done attempting system ${system} in pool ${pool}"
 
                     lock_tries=$(($lock_tries+1))
 

--- a/scripts/lock
+++ b/scripts/lock
@@ -352,6 +352,8 @@ UserLock() {
                         # We only want to attempt locking, not wait on it
                         if LockSystem "${system}" "1" "0" "${key}" $timeout ; then
                             # Locking succeeded on a board
+                            # We need to tell the user which one
+                            echo "${system}"
                             ret=$?
                             exit "${ret}"
                         fi

--- a/scripts/lock
+++ b/scripts/lock
@@ -340,9 +340,13 @@ UserLock() {
                 lock_tries=0
                 local ret=0
 
+                # Need to use a different name so as not to collide with other local variables
+                loop_retries="$total_retries"
+                loop_period="$retry_period"
+
                 # Loop until total_retries + 1 because we want to make the initial attempt,
                 # and then retry the correct number of times
-                while [ "${total_retries}" -eq -1 -o "${lock_tries}" -lt "$((${total_retries}+1))" ] ; do
+                while [ "${loop_retries}" -eq -1 ] || [ "${lock_tries}" -lt "$((${loop_retries}+1))" ] ; do
 
                     # Loop through and try all systems in the pool.
                     for system in $(Systems_"${pool}"); do
@@ -361,7 +365,8 @@ UserLock() {
 
                     lock_tries=$(($lock_tries+1))
 
-                    sleep "${retry_period}"
+                    sleep "${loop_period}"
+
                 done
 
                 # If we reach this point, we've exhausted all retry attempts

--- a/scripts/lock
+++ b/scripts/lock
@@ -190,7 +190,7 @@ UserLockUsage() {
     echo " -wait SYSTEM     Acquire the lock for the specified SYSTEM"
     echo " -cancel SYSTEM   Cancel '-wait' processes on the server that are waiting for specified SYSTEM and key"
     echo " -w TIME          Number of seconds to wait between each attempt to acquire the lock (default 8)"
-    echo " -t RETRIES       Number of retries to preform for acquiring the lock (default -1)"
+    echo " -t RETRIES       Number of retries to perform for acquiring the lock (default -1)"
     echo " -f               Forcefully releases a lock even if you are not the owner"
     echo " -k LOCK_KEY      Set a key inside the lock"
     echo " -T timeout       Allow lock to be reclaimed after timeout seconds"

--- a/scripts/lock
+++ b/scripts/lock
@@ -340,11 +340,15 @@ UserLock() {
                 lock_tries=0
                 local ret=0
 
-                while [ "${total_retries}" -eq -1 ] || [ "${lock_tries}" -lt "${total_retries}" ] ; do
+                # Loop until total_retries + 1 because we want to make the initial attempt,
+                # and then retry the correct number of times
+                while [ "${total_retries}" -eq -1 -o "${lock_tries}" -lt "$((${total_retries}+1))" ] ; do
 
+                    # Loop through and try all systems in the pool.
                     for system in $(Systems_"${pool}"); do
 
-                        # Note we do not retry and give a small retry period (which is unused)
+                        # Note we do not retry the individual lock attempt,
+                        # and give only a small retry period (which is unused)
                         # We only want to attempt locking, not wait on it
                         if LockSystem "${system}" "1" "0" "${key}" $timeout ; then
                             # Locking succeeded on a board
@@ -364,7 +368,9 @@ UserLock() {
 
             ;;
             -cancel)
-                CancelWait "${system}" "${key}"
+                for system in $(Systems_"${pool}"); do
+                    CancelWait "${system}" "${key}"
+                done
             ;;
             *)
                 echo "Unknown usage"

--- a/scripts/lock
+++ b/scripts/lock
@@ -282,47 +282,99 @@ UserLock() {
         *);;
     esac
 
-    IsSystemValid "${system}"
-    if [ $? -ne 0 ]; then
-        # If it's not a system, is it a pool?
-        IsPoolValid "${system}"
-        if [ $? -ne 0 ] ; then
-            echo "System or pool '$system' does not exist. Valid systems are"
-            SystemList
-            echo "Valid pools are"
-            PoolList
-            exit 1
-    fi
-        # Select a system from the pool
+    if IsSystemValid "${system}" ; then
+
+        case "${action}" in
+            -info)
+                LockSystemPrintInfo "${system}"
+            ;;
+            -mr-info)
+                LockSystemDumpInfo "${system}"
+            ;;
+            -signal)
+                UnlockSystem "${system}" "${force}" "${key}"
+            ;;
+            -wait)
+                if ! LockSystem "${system}" "${retry_period}" "${total_retries}" "${key}" $timeout; then
+                    echo "Failed to acquire lock for system (${system})"
+                    exit 2
+                fi
+            ;;
+            -cancel)
+                CancelWait "${system}" "${key}"
+            ;;
+            *)
+                echo "Unknown usage"
+                UserLockUsage
+                exit 1
+            ;;
+        esac
+
+    elif IsPoolValid "${system}" ; then
         pool=${system}
-        system=$(GetRandomSystemFromPool_"${pool}")
-        echo "${system}"
+
+        case "${action}" in
+            -info)
+                for system in $(Systems_"${pool}"); do
+                    LockSystemPrintInfo "${system}"
+                done
+            ;;
+            -mr-info)
+                for system in $(Systems_"${pool}"); do
+                    LockSystemDumpInfo "${system}"
+                done
+            ;;
+            -signal)
+                for system in $(Systems_"${pool}"); do
+                    UnlockSystem "${system}" "${force}" "${key}"
+                done
+            ;;
+            -wait)
+
+                # When attempting to lock a pool, we use the retry time and retry count
+                # given by the user for how often we attempt locking on the whole pool,
+                # not for lock attempts on a specific system.
+                # Each time the user-configured period elapses, we try (but do not wait
+                # on) locking each system in the pool.
+
+                lock_tries=0
+                local ret=0
+
+                while [ "${total_retries}" -eq -1 ] || [ "${lock_tries}" -lt "${total_retries}" ] ; do
+
+                    for system in $(Systems_"${pool}"); do
+
+                        # Note we do not retry and give a small retry period (which is unused)
+                        # We only want to attempt locking, not wait on it
+                        if LockSystem "${system}" "1" "0" "${key}" $timeout ; then
+                            # Locking succeeded on a board
+                            ret=$?
+                            exit "${ret}"
+                        fi
+                    done
+
+                    lock_tries=$(($lock_tries+1))
+
+                    sleep "${retry_period}"
+                done
+            ;;
+            -cancel)
+                CancelWait "${system}" "${key}"
+            ;;
+            *)
+                echo "Unknown usage"
+                UserLockUsage
+                exit 1
+            ;;
+        esac
+
+    else
+        echo "System or pool '$system' does not exist. Valid systems are"
+        SystemList
+        echo "Valid pools are"
+        PoolList
+        exit 1
     fi
 
-    case "${action}" in
-        -info)
-            LockSystemPrintInfo "${system}"
-        ;;
-        -mr-info)
-            LockSystemDumpInfo "${system}"
-        ;;
-        -signal)
-            UnlockSystem "${system}" "${force}" "${key}"
-        ;;
-        -wait)
-            if ! LockSystem "${system}" "${retry_period}" "${total_retries}" "${key}" $timeout; then
-                echo "Failed to acquire lock for system (${system})"
-                exit 2
-            fi
-        ;;
-        -cancel)
-            CancelWait "${system}" "${key}"
-        ;;
-        *)
-            echo "Unknown usage"
-            UserLockUsage
-            exit 1
-        ;;
-    esac
     exit 0
 }

--- a/scripts/lock
+++ b/scripts/lock
@@ -357,6 +357,11 @@ UserLock() {
 
                     sleep "${retry_period}"
                 done
+
+                # If we reach this point, we've exhausted all retry attempts
+                echo "Failed to acquire lock for any system in pool (${pool})"
+                exit 2
+
             ;;
             -cancel)
                 CancelWait "${system}" "${key}"

--- a/scripts/lock
+++ b/scripts/lock
@@ -97,7 +97,7 @@ LockSystem() {
     total_retries="$3"
     key="$4"
     newtimeout="$5"
-    timeout=""
+    oldtimeout=""
     owner=$(LockOwner "${system}")
 
     # Error checking - the same person can't relock the same lock
@@ -120,21 +120,21 @@ LockSystem() {
     then
         # Ensure timeout is either an integer or ignored
         # to avoid lockfile syntax errors
-        timeout="$(LockTimeout $system)" || timeout=""
-        case $timeout in
+        oldtimeout="$(LockTimeout $system)" || oldtimeout=""
+        case $oldtimeout in
             ''|*[!0-9]*)
                 # no valid timeout
-                timeout=""
+                oldtimeout=""
                 ;;
             *)
                 # valid timeout
-                timeout="-l ${timeout}"
+                oldtimeout="-l ${oldtimeout}"
                 ;;
         esac
     fi
     lockname="$(LockName ${system})"
     keyname="$(KeyName ${system})"
-    RemoteCommand "umask 0111 && lockfile -'${retry_period}'  $timeout -r '${total_retries}' '$lockname' && rm -f '$keyname' && printf '${key}' > '$keyname' && chmod a-w,g+r '$keyname' && chmod u+w $lockname && printf '$newtimeout' > $lockname && chmod a-w $lockname"
+    RemoteCommand "umask 0111 && lockfile -'${retry_period}'  $oldtimeout -r '${total_retries}' '$lockname' && rm -f '$keyname' && printf '${key}' > '$keyname' && chmod a-w,g+r '$keyname' && chmod u+w $lockname && printf '$newtimeout' > $lockname && chmod a-w $lockname"
 
     [ "$?" -ne  0 ] && return 3
 


### PR DESCRIPTION
This pull request substantially changes how the machine queue scripts handle pools.
Previously, when performing an operation on a pool, the mq would immediately randomly
select one member from the pool, then proceed with the requested operation as if the
user had asked to do it on that one member only.

These changes mean that (roughly) the pools now work by retrying the requested operation
on every member of the pool. In particular, this means that when waiting for locks on a pool where all
boards are locked by someone else, you will lock the first board to be released, rather than
the old behaviour which picked just one pool member and waited until that specifc board was free.
Details of the new behaviour follow.

## sem and run on individual boards
* Using ```sem``` and ```run``` for individual boards should work the same way it always did
    with the following exception:
* Previously if you locked a board with a key, then used ```run -n``` on the board,
    it would check that you owned the lock but not that you specified the right key.
    (You would have to give the right key when unlocking the board again later).
    Now, when you use ```run -n``` to run a job on a board you've already locked,
    you must give the key you locked the board with as well as owning the lock.
    If you give the wrong key, the scripts exit nonzero.
    Behaviour for pools with ```run -n``` matches this behaviour for boards.

## sem on pools
* When you attempt to lock a pool using ```sem -wait```, the scripts will attempt
    locking every member of the pool one after the other. If they succeed in locking
    one of the boards, the scripts will print which board you got and exit with code 0.
    If no pool member is lockable, the script will wait for the period specified by
    ```-w```, then retry locking every member of the pool one after the other.
    The script will retry the whole pool as many times as ```-t``` tells it to.
    If no board is successfully locked within the given number of retries, the script
    will exit non-zero.
* If you Ctrl+C during the wait for locking on a pool, the script will exit nonzero
    and you will not own any locks you didn't before. This is the same as it used to be.
* When you attempt to unlock a pool using ```sem -signal```, the scripts will attempt
    to unlock everything in the pool. Because of how unlocking works, this will only
    unlock the locks you own, and only if you're giving the right key. It will not affect
    anyone else's locks even if other people have locked boards in the same pool,
    provided you don't use ```-f```.
    There are no timeouts or retries on unlocking, and it always exits 0 whether or not something
    was unlocked (matching the current behaviour of ```sem``` on individuals) unless
    a script error happens.
* When you use ```sem -info``` on a pool, it prints information on the lock state
    of all the boards in that pool.

## run on pools
* When you use ```run``` on a pool, the script will follow the ```sem -wait``` procedure
    for attempting locking every member. Either it will run out of tries and give up,
    exiting nonzero, or it will succeed in locking a board. If it succeeds, the job you
    specify will proceed to run on that board. When the job is done, the board you locked
    will be unlocked and the script will exit 0.
* When you use ```run -r``` on a pool, the script will follow the ```sem -wait``` procedure
    for attempting to lock every member. If it gets one, the script will wait for you to enter
    Ctrl+D or Enter, and when you do it will unlock the board, clean up, and exit 0.
* When you use ```run -n``` on a pool, the script will attempt to run on each board in the
    pool, one after the other, but only actually run on the first board it finds where
    you already own the lock and have the right key. If the script finds a board where
    you have the lock and right key, it will run the job then exit 0. If you don't
    have the right lock/key for any of the boards in the pool, the script will continue
    retrying according to your retry parameters, until either
        - the lock state changes so that you have the lock and the right key on one of
            the boards in the pool (the job will run then the scripts exit 0)
        - the scripts have retried as many times as you told them to (the scripts will
            exit nonzero)
        - you manually cancel with Ctrl+C (the scripts will exit nonzero)
* If you Ctrl+C at any point during ```run```, the script will stop whatever job it's been
    doing, unlock any locks it has taken, and exit nonzero. This is the same as it used to be.
