### PR TITLE
tqma: Fix SoC

### DIFF
--- a/scripts/systems/tqma
+++ b/scripts/systems/tqma
@@ -26,7 +26,7 @@ ISA_tqma() {
 }
 
 SOC_tqma() {
-    echo "tqma8xx"
+    echo "imx8qxp"
 }
 
 CPU_tqma() {


### PR DESCRIPTION
Just noticed that the module is mistaken for a SoC.

The SoC is NXP i.MX 8X, specifically the i.MX 8QuadXPlus variant (i.MX 8QXP). The i.MX 8DXP is compatible, except is has only two cores. The tqma platform code should also work other modules or boards using the same SoC, like Colibri iMX8X.