### PR TITLE
Adding -f so rm will succeed whether or not the file is present

### DIFF
--- a/scripts/runner
+++ b/scripts/runner
@@ -56,15 +56,15 @@ RebootConsoleRunTwoFiles() {
         rootserverfile=$(RemoteCommandOn ${HOST} "mktemp")
         if ! scp "${kernel}" "${HOST}:${kernelfile}"; then
             echo "Failed to copy kernel image"
-            RemoteCommandOn ${HOST} rm "${kernelfile}"
-            RemoteCommandOn ${HOST} rm "${rootserverfile}"
+            RemoteCommandOn ${HOST} rm -f "${kernelfile}"
+            RemoteCommandOn ${HOST} rm -f "${rootserverfile}"
             RemoteCommandOn ${HOST} rm "${logfile}"
             return 1
         fi
         if ! scp "${rootserver}" "${HOST}:${rootserverfile}"; then
             echo "Failed to copy rootserver image"
-            RemoteCommandOn ${HOST} rm "${kernelfile}"
-            RemoteCommandOn ${HOST} rm "${rootserverfile}"
+            RemoteCommandOn ${HOST} rm -f "${kernelfile}"
+            RemoteCommandOn ${HOST} rm -f "${rootserverfile}"
             RemoteCommandOn ${HOST} rm "${logfile}"
             return 1
         fi
@@ -73,10 +73,10 @@ RebootConsoleRunTwoFiles() {
             dtbflag="-b $dtbfile"
             if ! scp "${dtb}" "${HOST}:${dtbfile}"; then
                 echo "Failed to copy dtb file"
-                RemoteCommandOn ${HOST} rm "${kernelfile}"
-                RemoteCommandOn ${HOST} rm "${rootserverfile}"
+                RemoteCommandOn ${HOST} rm -f "${kernelfile}"
+                RemoteCommandOn ${HOST} rm -f "${rootserverfile}"
                 RemoteCommandOn ${HOST} rm "${logfile}"
-                RemoteCommandOn ${HOST} rm "${dtbfile}"
+                RemoteCommandOn ${HOST} rm -f "${dtbfile}"
                 return 1
             fi
         fi
@@ -86,11 +86,11 @@ RebootConsoleRunTwoFiles() {
         if [ "${output}" != "" ]; then
             scp "${HOST}:${logfile}" "${output}"
         fi
-        RemoteCommandOn ${HOST} rm "${kernelfile}"
-        RemoteCommandOn ${HOST} rm "${rootserverfile}"
+        RemoteCommandOn ${HOST} rm -f "${kernelfile}"
+        RemoteCommandOn ${HOST} rm -f "${rootserverfile}"
         RemoteCommandOn ${HOST} rm "${logfile}"
         if [ ! -z "${dtb}" ]; then
-            RemoteCommandOn ${HOST} rm "${dtbfile}"
+            RemoteCommandOn ${HOST} rm -f "${dtbfile}"
         fi
         return $ret
     fi
@@ -133,7 +133,7 @@ RebootConsoleRunOneFile() {
         kernelfile=$(RemoteCommandOn ${HOST} "mktemp")
         if ! scp "${kernel}" "${HOST}:${kernelfile}"; then
             echo "Failed to copy kernel image"
-            RemoteCommandOn ${HOST} rm "${kernelfile}"
+            RemoteCommandOn ${HOST} rm -f "${kernelfile}"
             RemoteCommandOn ${HOST} rm "${logfile}"
             return 1
         fi
@@ -142,8 +142,8 @@ RebootConsoleRunOneFile() {
             dtbflag="-b $dtbfile"
             if ! scp "${dtb}" "${HOST}:${kernelfile}"; then
                 echo "Failed to copy dtb file"
-                RemoteCommandOn ${HOST} rm "${dtbfile}"
-                RemoteCommandOn ${HOST} rm "${kernelfile}"
+                RemoteCommandOn ${HOST} rm -f "${dtbfile}"
+                RemoteCommandOn ${HOST} rm -f "${kernelfile}"
                 RemoteCommandOn ${HOST} rm "${logfile}"
             fi
         fi
@@ -153,10 +153,10 @@ RebootConsoleRunOneFile() {
         if [ "${output}" != "" ]; then
             scp "${HOST}:${logfile}" "${output}"
         fi
-        RemoteCommandOn ${HOST} rm "${kernelfile}"
+        RemoteCommandOn ${HOST} rm -f "${kernelfile}"
         RemoteCommandOn ${HOST} rm "${logfile}"
         if [ ! -z "${dtb}" ]; then
-            RemoteCommandOn ${HOST} rm "${dtbfile}"
+            RemoteCommandOn ${HOST} rm -f "${dtbfile}"
         fi
         return $ret
     fi

--- a/scripts/runner
+++ b/scripts/runner
@@ -56,16 +56,12 @@ RebootConsoleRunTwoFiles() {
         rootserverfile=$(RemoteCommandOn ${HOST} "mktemp")
         if ! scp "${kernel}" "${HOST}:${kernelfile}"; then
             echo "Failed to copy kernel image"
-            RemoteCommandOn ${HOST} rm -f "${kernelfile}"
-            RemoteCommandOn ${HOST} rm -f "${rootserverfile}"
-            RemoteCommandOn ${HOST} rm "${logfile}"
+            RemoteCommandOn ${HOST} rm -f "${kernelfile}" "${rootserverfile}" "${logfile}"
             return 1
         fi
         if ! scp "${rootserver}" "${HOST}:${rootserverfile}"; then
             echo "Failed to copy rootserver image"
-            RemoteCommandOn ${HOST} rm -f "${kernelfile}"
-            RemoteCommandOn ${HOST} rm -f "${rootserverfile}"
-            RemoteCommandOn ${HOST} rm "${logfile}"
+            RemoteCommandOn ${HOST} rm -f "${kernelfile}" "${rootserverfile}" "${logfile}"
             return 1
         fi
         if [ ! -z "${dtb}" ]; then
@@ -73,10 +69,7 @@ RebootConsoleRunTwoFiles() {
             dtbflag="-b $dtbfile"
             if ! scp "${dtb}" "${HOST}:${dtbfile}"; then
                 echo "Failed to copy dtb file"
-                RemoteCommandOn ${HOST} rm -f "${kernelfile}"
-                RemoteCommandOn ${HOST} rm -f "${rootserverfile}"
-                RemoteCommandOn ${HOST} rm "${logfile}"
-                RemoteCommandOn ${HOST} rm -f "${dtbfile}"
+                RemoteCommandOn ${HOST} rm -f "${kernelfile}" "${rootserverfile}" "${logfile}" "${dtbfile}"
                 return 1
             fi
         fi
@@ -86,9 +79,7 @@ RebootConsoleRunTwoFiles() {
         if [ "${output}" != "" ]; then
             scp "${HOST}:${logfile}" "${output}"
         fi
-        RemoteCommandOn ${HOST} rm -f "${kernelfile}"
-        RemoteCommandOn ${HOST} rm -f "${rootserverfile}"
-        RemoteCommandOn ${HOST} rm "${logfile}"
+        RemoteCommandOn ${HOST} rm -f "${kernelfile}" "${rootserverfile}" "${logfile}"
         if [ ! -z "${dtb}" ]; then
             RemoteCommandOn ${HOST} rm -f "${dtbfile}"
         fi
@@ -133,8 +124,7 @@ RebootConsoleRunOneFile() {
         kernelfile=$(RemoteCommandOn ${HOST} "mktemp")
         if ! scp "${kernel}" "${HOST}:${kernelfile}"; then
             echo "Failed to copy kernel image"
-            RemoteCommandOn ${HOST} rm -f "${kernelfile}"
-            RemoteCommandOn ${HOST} rm "${logfile}"
+            RemoteCommandOn ${HOST} rm -f "${kernelfile}" "${logfile}"
             return 1
         fi
         if [ ! -z "${dtb}" ]; then
@@ -142,9 +132,7 @@ RebootConsoleRunOneFile() {
             dtbflag="-b $dtbfile"
             if ! scp "${dtb}" "${HOST}:${kernelfile}"; then
                 echo "Failed to copy dtb file"
-                RemoteCommandOn ${HOST} rm -f "${dtbfile}"
-                RemoteCommandOn ${HOST} rm -f "${kernelfile}"
-                RemoteCommandOn ${HOST} rm "${logfile}"
+                RemoteCommandOn ${HOST} rm -f "${dtbfile}" "${kernelfile}" "${logfile}"
             fi
         fi
 
@@ -153,8 +141,7 @@ RebootConsoleRunOneFile() {
         if [ "${output}" != "" ]; then
             scp "${HOST}:${logfile}" "${output}"
         fi
-        RemoteCommandOn ${HOST} rm -f "${kernelfile}"
-        RemoteCommandOn ${HOST} rm "${logfile}"
+        RemoteCommandOn ${HOST} rm -f "${kernelfile}" "${logfile}"
         if [ ! -z "${dtb}" ]; then
             RemoteCommandOn ${HOST} rm -f "${dtbfile}"
         fi


### PR DESCRIPTION
While running a job, the mq uploads kernel, (and optionally) ramdisk and dtb files to /tmp on tftp for use. They then get copied to another location where the relevant board downloads and runs them.
After a job completes, the mq removes the kernel, ramdisk, and dtb files from /tmp which were uploaded to tftp for use by the job.

We've recently been having issues with /tmp on tftp filling up with files that weren't deleted properly. As a mitigation, we've changed the scripts on tftp to move files out of /tmp rather than copy them, so it's less likely they'll be left behind.
However, when the job runs properly this means the kernel/ramdisk/dtb files are no longer in /tmp when the job finishes, so mq reports an error because the files it tries to remove from /tmp don't exist. This would likely cause all successful CI runs to register as failures, since the mq scripts will exit with nonzero values.

This pull request adds -f to the mq scripts rm command for images in /tmp, so that rm will return success whether the file it tried to remove exists or not. This means that the image having been moved before rm runs won't cause an otherwise successful mq job to register as having failed.