### PR TITLE
Rename cheshire1/2 to serengeti1/2

### DIFF
--- a/scripts/systems/serengeti1
+++ b/scripts/systems/serengeti1
@@ -9,54 +9,54 @@ if [ "${SCRIPT_PATH}" = "" ]; then
     exit -1
 fi
 
-SystemNumFiles_cheshire2() {
+SystemNumFiles_serengeti1() {
     echo 1
 }
 
-SystemName_cheshire2() {
-    echo "cheshire2"
+SystemName_serengeti1() {
+    echo "serengeti1"
 }
 
-SystemPowerOff_cheshire2() {
-    RebootShutdown cheshire2
+SystemPowerOff_serengeti1() {
+    RebootShutdown serengeti1
 }
 
-Arch_cheshire2() {
+Arch_serengeti1() {
     echo "riscv"
 }
 
-ISA_cheshire2() {
+ISA_serengeti1() {
     echo "rv64imafdcsuh"
 }
 
-SOC_cheshire2() {
+SOC_serengeti1() {
     echo "PULP Platform Cheshire"
 }
 
-CPU_cheshire2() {
+CPU_serengeti1() {
     echo "CVA6"
 }
 
-Cores_cheshire2() {
+Cores_serengeti1() {
     echo "1"
 }
 
-RAM_cheshire2() {
+RAM_serengeti1() {
     echo "1GB"
 }
 
-MaxCLK_cheshire2() {
+MaxCLK_serengeti1() {
     echo "50MHz"
 }
 
-Sel4Plat_cheshire2() {
-    echo "cheshire"
+Sel4Plat_serengeti1() {
+    echo "serengeti"
 }
 
-PXELinux_cheshire2() {
+PXELinux_serengeti1() {
     echo "no"
 }
 
-DTB_cheshire2() {
+DTB_serengeti1() {
     echo "no"
 }

--- a/scripts/systems/serengeti2
+++ b/scripts/systems/serengeti2
@@ -9,54 +9,54 @@ if [ "${SCRIPT_PATH}" = "" ]; then
     exit -1
 fi
 
-SystemNumFiles_cheshire1() {
+SystemNumFiles_serengeti2() {
     echo 1
 }
 
-SystemName_cheshire1() {
-    echo "cheshire1"
+SystemName_serengeti2() {
+    echo "serengeti2"
 }
 
-SystemPowerOff_cheshire1() {
-    RebootShutdown cheshire1
+SystemPowerOff_serengeti2() {
+    RebootShutdown serengeti2
 }
 
-Arch_cheshire1() {
+Arch_serengeti2() {
     echo "riscv"
 }
 
-ISA_cheshire1() {
+ISA_serengeti2() {
     echo "rv64imafdcsuh"
 }
 
-SOC_cheshire1() {
+SOC_serengeti2() {
     echo "PULP Platform Cheshire"
 }
 
-CPU_cheshire1() {
+CPU_serengeti2() {
     echo "CVA6"
 }
 
-Cores_cheshire1() {
+Cores_serengeti2() {
     echo "1"
 }
 
-RAM_cheshire1() {
+RAM_serengeti2() {
     echo "1GB"
 }
 
-MaxCLK_cheshire1() {
+MaxCLK_serengeti2() {
     echo "50MHz"
 }
 
-Sel4Plat_cheshire1() {
-    echo "cheshire"
+Sel4Plat_serengeti2() {
+    echo "serengeti"
 }
 
-PXELinux_cheshire1() {
+PXELinux_serengeti2() {
     echo "no"
 }
 
-DTB_cheshire1() {
+DTB_serengeti2() {
     echo "no"
 }


### PR DESCRIPTION
We're moving these genesys2 FPGA boards to run serengeti images by default, so calling them Serengeti is easier.

These aren't used by the seL4 CI, just internally at Trustworthy Systems.